### PR TITLE
Allow arrays of middleware as routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ function map (app, context) {
 
     var valid_routes = _.filter(routes, function (route) {
       if (typeof resource[route[2]] === 'function') return true;
+      if (_.isArray(resource[route[2]])) return true;
     });
 
 


### PR DESCRIPTION
In Express you can either provide a single middleware function as a route, or an array of middlewares. This adds support for middleware arrays.
