### PR TITLE
Prepare release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcemap",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Resourceful routing for Express 4.x",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/olalonde/express-resourceful.git"
+    "url": "git://github.com/olalonde/resourcemap.git"
   },
   "keywords": [
     "express",
@@ -22,9 +22,9 @@
   "author": "Olivier Lalonde <olalonde@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/olalonde/express-resourceful/issues"
+    "url": "https://github.com/olalonde/resourcemap/issues"
   },
-  "homepage": "https://github.com/olalonde/express-resourceful",
+  "homepage": "https://github.com/olalonde/resourcemap",
   "dependencies": {
     "debug": "^0.8.0",
     "underscore": "^1.6.0",


### PR DESCRIPTION
Down the line I'd like to enable release automation via Travis, but https://travis-ci.org/olalonde/resourcemap requires admin permissions. @olalonde could you enable it there?